### PR TITLE
Redirect to profile after successful sign in

### DIFF
--- a/assets/auth.js
+++ b/assets/auth.js
@@ -75,6 +75,14 @@
       return msg;
     }
 
+    function goToProfile() {
+      try {
+        window.location.href = "profile.html";
+      } catch (_) {
+        // ignore
+      }
+    }
+
     // ---- sign in (устойчивый, без 422) ----
     document.getElementById("doSignIn").onclick = async function () {
       clearError();
@@ -86,7 +94,7 @@
         // 1) штатный вход
         var r1 = await client.auth.signInWithPassword({ email: email, password: password });
         if (!r1.error && r1.data && r1.data.session) {
-          closeModal(); await refreshUI(); return;
+          closeModal(); await refreshUI(); goToProfile(); return;
         }
 
         // 2) резерв: прямой POST
@@ -118,7 +126,7 @@
           }
         }
 
-        closeModal(); await refreshUI();
+        closeModal(); await refreshUI(); goToProfile();
       } catch (e) {
         showError(normalize(e && e.message ? e.message : String(e)));
       }


### PR DESCRIPTION
## Summary
- redirect users to profile.html after a successful password sign-in
- keep the UI refresh and modal closing behaviour intact while navigating to the profile

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e20aa554fc83259d2a55455f8c4d4b