### PR TITLE
Close auth modal after successful sign-in

### DIFF
--- a/assets/auth.js
+++ b/assets/auth.js
@@ -221,7 +221,10 @@
     renderUserWidget({ user: session.user, profile: profile });
   }
 
-  client.auth.onAuthStateChange(async function () { await refreshUI(); });
+  client.auth.onAuthStateChange(async function (event, session) {
+    if (event === "SIGNED_IN" || (session && session.user)) { closeModal(); }
+    await refreshUI();
+  });
   window.addEventListener("DOMContentLoaded", refreshUI);
 
   // export


### PR DESCRIPTION
## Summary
- close the auth modal when Supabase signals a signed-in session
- keep the UI refresh to ensure buttons and the user widget stay up to date

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e20d6f97148325a2adba11a3c0d473