### PR TITLE
Add user profile card in header and show profile email

### DIFF
--- a/assets/auth.js
+++ b/assets/auth.js
@@ -22,8 +22,11 @@
     ".auth-error{color:#ef4444;font-size:13px;margin-top:6px;white-space:pre-wrap}" +
     ".userwidget{position:relative;display:inline-flex;align-items:center;gap:8px;margin-left:8px}" +
     ".userwidget .avatar{width:28px;height:28px;border-radius:999px;object-fit:cover;border:1px solid #2f3640;background:#1f2937}" +
-    ".userwidget .name{cursor:pointer;user-select:none}" +
-    ".userwidget .menu{position:absolute;right:0;top:120%;background:#0f172a;border:1px solid #2f3640;border-radius:10px;min-width:180px;display:none;z-index:2147483647}" +
+    ".userwidget .profile-chip{display:inline-flex;align-items:center;gap:8px;padding:6px 12px;border-radius:999px;border:1px solid #2f3640;background:#0f172a;color:#e5e7eb;font-size:14px;line-height:1;text-decoration:none}" +
+    ".userwidget .profile-chip:hover{background:#111827}" +
+    ".userwidget .menu-btn{border:1px solid #2f3640;background:#0f172a;color:#e5e7eb;border-radius:12px;padding:6px 8px;cursor:pointer}" +
+    ".userwidget .menu-btn:hover{background:#111827}" +
+    ".userwidget .menu{position:absolute;right:0;top:120%;background:#0f172a;border:1px solid #2f3640;border-radius:10px;min-width:160px;display:none;z-index:2147483647}" +
     ".userwidget .menu a,.userwidget .menu button{display:block;width:100%;text-align:left;padding:8px 10px;border:0;background:transparent;color:#e5e7eb;cursor:pointer}" +
     ".userwidget .menu a:hover,.userwidget .menu button:hover{background:#111827}";
   var st = document.createElement("style"); st.textContent = css; document.head.appendChild(st);
@@ -206,17 +209,40 @@
                  "";
 
     container.innerHTML =
-      '<img class="avatar" src="' + (avatar || 'assets/avatar-placeholder.png') + '" alt="avatar" onerror="this.src=\'assets/avatar-placeholder.png\'"/>' +
-      '<span class="name" id="userName" title="Нажми, чтобы открыть меню">' + name + '</span>' +
+      '<a class="profile-chip" id="profileChip" href="profile.html" title="Открыть профиль">' +
+      '  <img class="avatar" src="' + (avatar || 'assets/avatar-placeholder.png') + '" alt="avatar" onerror="this.src=\\'assets/avatar-placeholder.png\\'"/>' +
+      '  <span class="name">' + name + '</span>' +
+      '</a>' +
+      '<button class="menu-btn" id="profileMenuBtn" type="button" aria-haspopup="true" aria-expanded="false" title="Меню профиля">⋯</button>' +
       '<div class="menu" id="userMenu">' +
-      '  <a href="profile.html">Профиль</a>' +
-      '  <button id="logoutBtn">Выйти</button>' +
+      '  <button id="logoutBtn" type="button">Выйти</button>' +
       '</div>';
 
-    var nameEl = container.querySelector("#userName");
+    var menuBtn = container.querySelector("#profileMenuBtn");
     var menu = container.querySelector("#userMenu");
-    nameEl.onclick = function () { menu.style.display = (menu.style.display === "block" ? "none" : "block"); };
-    container.addEventListener("mouseleave", function () { menu.style.display = "none"; });
+    function hideMenu(){ if(menu){ menu.style.display = "none"; if(menuBtn) menuBtn.setAttribute("aria-expanded","false"); } }
+    function toggleMenu(){
+      if(!menu) return;
+      var isOpen = menu.style.display === "block";
+      if(isOpen){
+        hideMenu();
+      }else{
+        menu.style.display = "block";
+        if(menuBtn) menuBtn.setAttribute("aria-expanded", "true");
+        var handler = function(ev){
+          if(!container.contains(ev.target)){
+            hideMenu();
+            document.removeEventListener("click", handler);
+          }
+        };
+        setTimeout(function(){ document.addEventListener("click", handler); }, 0);
+      }
+    }
+
+    if(menuBtn){
+      menuBtn.onclick = function (e) { e.preventDefault(); toggleMenu(); };
+    }
+    container.addEventListener("mouseleave", hideMenu);
     container.querySelector("#logoutBtn").onclick = async function () { await client.auth.signOut(); };
   }
 

--- a/assets/profile.js
+++ b/assets/profile.js
@@ -23,18 +23,23 @@
     if(nameEl) nameEl.value = '';
     const avatarEl = document.getElementById('avatar');
     if(avatarEl) avatarEl.src = placeholderAvatar;
+    const emailEl = document.getElementById('profileEmail');
+    if(emailEl) emailEl.textContent = '—';
   }
 
   async function loadProfile(){
     const SB = await waitForAuth();
     const user = await requireAuth(SB).catch(()=>null);
-    if(!user) return;
+    if(!user){ msg('Войдите, чтобы настроить профиль.'); clearProfileUI(); return; }
     await SB.from('profiles').upsert({ user_id: user.id, email: user.email }).select().single().catch(()=>{});
     const { data, error } = await SB.from('profiles').select('full_name, avatar_url, email').eq('user_id', user.id).single();
     if(error){ msg('Ошибка чтения профиля: ' + error.message); return; }
     document.getElementById('fullName').value = data?.full_name || '';
     const url = data?.avatar_url || placeholderAvatar;
     document.getElementById('avatar').src = url;
+    const emailEl = document.getElementById('profileEmail');
+    if(emailEl) emailEl.textContent = data?.email || user.email || '—';
+    msg('');
   }
 
   async function saveProfile(){
@@ -81,6 +86,7 @@
             loadProfile().catch(()=>{});
           }else if(event === 'SIGNED_OUT'){
             clearProfileUI();
+            msg('Войдите, чтобы настроить профиль.');
           }
         });
       }catch(e){

--- a/profile.html
+++ b/profile.html
@@ -7,12 +7,16 @@
   <link rel="stylesheet" href="assets/style.css" />
   <style>
     .profile { max-width: 720px; margin: 24px auto; }
-    .row { display:flex; gap:16px; align-items:center; }
+    .row { display:flex; gap:16px; align-items:center; flex-wrap:wrap; }
     .card { border:1px solid #263040; border-radius:16px; padding:16px; background:#111827; color:#e5e7eb; }
     .btn { display:inline-block; padding:8px 12px; border-radius:10px; border:1px solid #2f3640; background:#0f172a; color:#e5e7eb; cursor:pointer; margin-right:8px; }
     input[type="text"] { padding:10px 12px; border-radius:12px; border:1px solid #2f3640; background:#0f172a; color:#e5e7eb; width:100%; }
     .avatar { width:96px; height:96px; border-radius:999px; object-fit:cover; border:1px solid #2f3640; background:#1f2937; }
     label.file { display:inline-block; }
+    .email-row { display:flex; flex-direction:column; gap:4px; margin-top:16px; }
+    .email-label { font-size:14px; color:#9ca3af; }
+    .email-value { display:inline-flex; align-items:center; gap:8px; padding:10px 12px; border-radius:12px; border:1px solid #2f3640; background:#0f172a; font-weight:600; word-break:break-all; }
+    @media (max-width:540px){ .btn{margin-bottom:8px;} }
   </style>
 </head>
 <body>
@@ -45,6 +49,11 @@
         <small class="muted">Рекомендуется квадратное изображение 512×512, PNG/JPG.</small>
       </div>
     </div>
+    <div class="email-row">
+      <span class="email-label">Email</span>
+      <div id="profileEmail" class="email-value">—</div>
+    </div>
+
     <div style="margin-top:16px">
       <label>ФИО
         <input id="fullName" type="text" placeholder="Иванов Иван Иванович">


### PR DESCRIPTION
## Summary
- add a persistent profile chip in the header that links to the profile page and keeps logout in a menu
- show the signed-in email on the profile page and clear it when signing out
- refresh profile scripts so users are prompted to log in before editing their profile details

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e2407a270c8325add312bb6c11839e