### PR TITLE
Restore login button across site headers

### DIFF
--- a/about.html
+++ b/about.html
@@ -30,6 +30,8 @@
     </nav>
     <button class="btn" id="modeBtn">🌓 <span data-i18n="ui_theme">Тема</span></button>
     <button class="btn" id="langBtn">🌐 <span id="langLabel">RU</span></button>
+    <button class="btn" id="authOpen" type="button">🔐 <span data-i18n="ui_login">Войти</span></button>
+    <div class="userwidget" id="userWidget" aria-live="polite"></div>
   </div>
 </header>
 

--- a/assets/i18n.js
+++ b/assets/i18n.js
@@ -3,14 +3,14 @@
   const dict = {
     ru: {
       nav_about:'Обо мне', nav_recipes:'Рецепты', nav_news:'Новости',
-      nav_packs:'Пачки', nav_gallery:'Галерея', ui_theme:'Тема',
+      nav_packs:'Пачки', nav_gallery:'Галерея', ui_theme:'Тема', ui_login:'Войти',
       hero_badge:'☕ Привет! Я Федя — веду кофейный блог',
       hero_title:'Новости, рецепты и коллекция пачек — всё про кофе',
       hero_lead:'Пишу об актуальном в индустрии, делюсь проверенными рецептами (V60, эспрессо, аэропресс) и веду каталог любимых пачек с заметками о вкусе.'
     },
     en: {
       nav_about:'About', nav_recipes:'Recipes', nav_news:'News',
-      nav_packs:'Bags', nav_gallery:'Gallery', ui_theme:'Theme',
+      nav_packs:'Bags', nav_gallery:'Gallery', ui_theme:'Theme', ui_login:'Sign in',
       hero_badge:"☕ Hi! I'm Fedya — running a coffee blog",
       hero_title:'News, recipes & bag collection — all about coffee',
       hero_lead:'I cover industry news, share recipes (V60, espresso, AeroPress) and keep a catalog of my favorite bags with tasting notes.'

--- a/gallery.html
+++ b/gallery.html
@@ -30,6 +30,8 @@
     </nav>
     <button class="btn" id="modeBtn">🌓 <span data-i18n="ui_theme">Тема</span></button>
     <button class="btn" id="langBtn">🌐 <span id="langLabel">RU</span></button>
+    <button class="btn" id="authOpen" type="button">🔐 <span data-i18n="ui_login">Войти</span></button>
+    <div class="userwidget" id="userWidget" aria-live="polite"></div>
   </div>
 </header>
 

--- a/index.html
+++ b/index.html
@@ -30,6 +30,8 @@
     </nav>
     <button class="btn" id="modeBtn">🌓 <span data-i18n="ui_theme">Тема</span></button>
     <button class="btn" id="langBtn">🌐 <span id="langLabel">RU</span></button>
+    <button class="btn" id="authOpen" type="button">🔐 <span data-i18n="ui_login">Войти</span></button>
+    <div class="userwidget" id="userWidget" aria-live="polite"></div>
   </div>
 </header>
 

--- a/news.html
+++ b/news.html
@@ -30,6 +30,8 @@
     </nav>
     <button class="btn" id="modeBtn">🌓 <span data-i18n="ui_theme">Тема</span></button>
     <button class="btn" id="langBtn">🌐 <span id="langLabel">RU</span></button>
+    <button class="btn" id="authOpen" type="button">🔐 <span data-i18n="ui_login">Войти</span></button>
+    <div class="userwidget" id="userWidget" aria-live="polite"></div>
   </div>
 </header>
 

--- a/packs.html
+++ b/packs.html
@@ -30,6 +30,8 @@
     </nav>
     <button class="btn" id="modeBtn">🌓 <span data-i18n="ui_theme">Тема</span></button>
     <button class="btn" id="langBtn">🌐 <span id="langLabel">RU</span></button>
+    <button class="btn" id="authOpen" type="button">🔐 <span data-i18n="ui_login">Войти</span></button>
+    <div class="userwidget" id="userWidget" aria-live="polite"></div>
   </div>
 </header>
 

--- a/profile.html
+++ b/profile.html
@@ -30,6 +30,10 @@
       &nbsp;•&nbsp;<a href="gallery.html">Галерея</a>
       &nbsp;•&nbsp;<a href="studio.html">Студия</a>
     </nav>
+    <button class="btn" id="modeBtn">🌓 <span data-i18n="ui_theme">Тема</span></button>
+    <button class="btn" id="langBtn">🌐 <span id="langLabel">RU</span></button>
+    <button class="btn" id="authOpen" type="button">🔐 <span data-i18n="ui_login">Войти</span></button>
+    <div class="userwidget" id="userWidget" aria-live="polite"></div>
   </div>
 </header>
 

--- a/recipes.html
+++ b/recipes.html
@@ -30,6 +30,8 @@
     </nav>
     <button class="btn" id="modeBtn">🌓 <span data-i18n="ui_theme">Тема</span></button>
     <button class="btn" id="langBtn">🌐 <span id="langLabel">RU</span></button>
+    <button class="btn" id="authOpen" type="button">🔐 <span data-i18n="ui_login">Войти</span></button>
+    <div class="userwidget" id="userWidget" aria-live="polite"></div>
   </div>
 </header>
 


### PR DESCRIPTION
## Summary
- add a static login button and user-widget container to each header so the control is present even if scripts fail to run
- extend the language dictionary with the new login label for both Russian and English locales

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68e24357eef0832597926c6a1c697712